### PR TITLE
chewOut now supports Pop! NC

### DIFF
--- a/src/CageBot.ts
+++ b/src/CageBot.ts
@@ -354,8 +354,22 @@ export class CageBot {
   }
 
   async chewOut(): Promise<void> {
-    await this._client.visitUrl("place.php");
-    await this._client.visitUrl("choice.php", { whichchoice: 212, option: 1 });
+    const adventureResponse = await this._client.visitUrl("adventure.php", {
+		snarfblat: 166,
+	  });
+
+	if (/Despite All Your Rage/.test(adventureResponse)) {
+	await this._client.visitUrl("choice.php", {
+		whichchoice: 212,
+		option: 1,
+	});
+	} else if (/Pop!/.test(adventureResponse)) {
+	await this._client.visitUrl("choice.php", {
+		whichchoice: 296,
+		option: 1,
+	});
+	}
+	  
     this._amCaged = false;
     this._cageStatus = undefined;
   }


### PR DESCRIPTION
This should prevent the cageBot from getting stuck in the cage if hobo has been flooded. chewOut now supports both non combats Despite All Your Rage (Hobo not flooded) and Pop! (hobo flooded)

Don't know how to confirm it is working except to be run by a user. If anyone knows of a way to do validation testing please let me know. I'm game to do it.