### PR TITLE
Added consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ reads "runaway;repeat". If your account has means of running freely,
 feel free to add them too, but I take no responsibility for failures.
 If you need to tiebreak equipment, +noncombat rate is nice too.
 
+Optionally manually stock bot with the items below for consumption.
+Bot must be at least the associated level to consume these items.
+Currently bot will not buy these, only uses from inventory.
+
+- Fleetwood mac 'n' cheese (Level 8)
+- Crimbo pie (Level 7)
+- Psychotic Train wine (Level 11)
+- Middle of the Road™ brand whiskey (No level requirement)
+
 ## RUNNING
 To run cagebot, either run `npm run start` in the root directory, or just `node dist/index.js`, both are equivalent.
 

--- a/src/KoLClient.ts
+++ b/src/KoLClient.ts
@@ -165,6 +165,20 @@ export class KoLClient {
     await this.useChatMacro(`/w ${recipient.id} ${message}`);
   }
 
+  async eat(foodID: number): Promise<void> {
+	await this.visitUrl("inv_eat.php", {
+		which: 1,
+		whichitem: foodID,
+	  });
+  }
+
+  async drink(drinkID: number): Promise<void> {
+	await this.visitUrl("inv_booze.php", {
+		which: 1,
+		whichitem: drinkID,
+	  });
+  }
+
   async fetchNewWhispers(): Promise<PrivateMessage[]> {
     const newChatMessagesResponse = await this.visitUrl("newchatmessages.php", {
       j: 1,
@@ -229,4 +243,33 @@ export class KoLClient {
     if (apiResponse) return parseInt(apiResponse["adventures"], 10);
     return 0;
   }
+
+  async getFull(): Promise<number> {
+    const apiResponse = await this.visitUrl("api.php", {
+      what: "status",
+      for: "Cagesitter (Maintained by Phillammon)",
+    });
+    if (apiResponse) return parseInt(apiResponse["full"], 10);
+    return 0;
+  }
+
+  async getDrunk(): Promise<number> {
+    const apiResponse = await this.visitUrl("api.php", {
+      what: "status",
+      for: "Cagesitter (Maintained by Phillammon)",
+    });
+    if (apiResponse) return parseInt(apiResponse["drunk"], 10);
+    return 0;
+  }
+
+  async getLevel(): Promise<number> {
+    const apiResponse = await this.visitUrl("api.php", {
+      what: "status",
+      for: "Cagesitter (Maintained by Phillammon)",
+    });
+    if (apiResponse) return parseInt(apiResponse["level"], 10);
+    return 0;
+  }
+
+  
 }


### PR DESCRIPTION
Hardcodes eating and drinking. Only consumes something when actively searching for a cage and have run out of adventures.

Tested advLeft and updated statusReport functions on a multi. Correctly ate/drank when low on adv.

Only code not explicitly tested is lines 139 and 193 in CageBot.ts